### PR TITLE
Update to Swift 6 and modernize package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Packages
 /*.xcodeproj
 xcuserdata/
+.swiftpm/xcode

--- a/Package.swift
+++ b/Package.swift
@@ -1,14 +1,15 @@
-// swift-tools-version:5.2
+// swift-tools-version:6.0
 
 import PackageDescription
 
 let package = Package(
     name: "Dynamic",
     platforms: [
-        .macOS(.v10_12),
-        .iOS(.v10),
-        .tvOS(.v10),
-        .watchOS(.v3)
+        .macOS(.v13),
+        .iOS(.v16),
+        .tvOS(.v16),
+        .watchOS(.v9),
+        .visionOS(.v1)
     ],
     products: [
         .library(name: "Dynamic", targets: ["Dynamic"])
@@ -17,6 +18,5 @@ let package = Package(
     targets: [
         .target(name: "Dynamic", dependencies: []),
         .testTarget(name: "DynamicTests", dependencies: ["Dynamic"])
-    ],
-    swiftLanguageVersions: [.v5]
+    ]
 )

--- a/Sources/Dynamic/Dynamic.swift
+++ b/Sources/Dynamic/Dynamic.swift
@@ -5,17 +5,24 @@
 //
 
 import Foundation
+import os
 
 public typealias ObjC = Dynamic
 
 @dynamicCallable
 @dynamicMemberLookup
-public class Dynamic: CustomDebugStringConvertible, Loggable {
-    public static var loggingEnabled: Bool = false {
-        didSet {
-            Invocation.loggingEnabled = loggingEnabled
+public class Dynamic: CustomDebugStringConvertible, Loggable, @unchecked Sendable {
+    private static let _loggingEnabled = OSAllocatedUnfairLock(initialState: false)
+    public static var loggingEnabled: Bool {
+        get {
+            _loggingEnabled.withLock { $0 }
+        }
+        set {
+            _loggingEnabled.withLock { $0 = newValue }
+            Invocation.loggingEnabled = newValue
         }
     }
+
     var loggingEnabled: Bool { Self.loggingEnabled }
 
     public static let `nil` = Dynamic(nil)
@@ -237,14 +244,14 @@ extension Dynamic {
             let returnType = invocation.returnType,
             invocation.returnsAny else { return nil }
 
-        let buffer = UnsafeMutablePointer<Int8>.allocate(capacity: invocation.returnLength)
-        defer { buffer.deallocate() }
-        buffer.initialize(repeating: 0, count: invocation.returnLength)
+        return withUnsafeTemporaryAllocation(of: Int8.self, capacity: invocation.returnLength) { buffer in
+            buffer.initialize(repeating: 0)
 
-        invocation.getReturnValue(result: &buffer.pointee)
+            invocation.getReturnValue(result: &buffer.baseAddress!.pointee)
 
-        let value = NSValue(bytes: buffer, objCType: UnsafePointer<Int8>(returnType))
-        return value
+            let value = NSValue(bytes: buffer.baseAddress!, objCType: UnsafePointer<Int8>(returnType))
+            return value
+        }
     }
 
     public var asObject: NSObject? { asAnyObject as? NSObject }
@@ -289,11 +296,10 @@ extension Dynamic {
             return nil
         }
 
-        let buffer = UnsafeMutablePointer<T>.allocate(capacity: 1)
-        defer { buffer.deallocate() }
-        value.getValue(buffer)
-
-        return buffer.pointee
+        return withUnsafeTemporaryAllocation(of: T.self, capacity: 1) { buffer in
+            value.getValue(buffer.baseAddress!)
+            return buffer[0]
+        }
     }
 }
 

--- a/Sources/Dynamic/Invocation.swift
+++ b/Sources/Dynamic/Invocation.swift
@@ -5,9 +5,19 @@
 //
 
 import Foundation
+import os
 
 class Invocation: Loggable {
-    public static var loggingEnabled: Bool = false
+    private static let _loggingEnabled = OSAllocatedUnfairLock(initialState: false)
+    public static var loggingEnabled: Bool {
+        get {
+            _loggingEnabled.withLock { $0 }
+        }
+        set {
+            _loggingEnabled.withLock { $0 = newValue }
+        }
+    }
+
     var loggingEnabled: Bool { Self.loggingEnabled }
 
     private let target: NSObject
@@ -126,16 +136,14 @@ class Invocation: Loggable {
 
         if let valueArgument = argument as? NSValue {
             /// Get the type byte size
-            let typeSize = UnsafeMutablePointer<Int>.allocate(capacity: 1)
-            defer { typeSize.deallocate() }
-            NSGetSizeAndAlignment(valueArgument.objCType, typeSize, nil)
+            var typeSize: Int = 0
+            NSGetSizeAndAlignment(valueArgument.objCType, &typeSize, nil)
 
             /// Get the actual value
-            let buffer = UnsafeMutablePointer<Int8>.allocate(capacity: typeSize.pointee)
-            defer { buffer.deallocate() }
-            valueArgument.getValue(buffer)
-
-            method(invocation, selector, buffer, index)
+            withUnsafeTemporaryAllocation(of: Int8.self, capacity: typeSize) { buffer in
+                valueArgument.getValue(buffer.baseAddress!)
+                method(invocation, selector, buffer.baseAddress!, index)
+            }
         } else {
             withUnsafePointer(to: argument) { pointer in
                 method(invocation, selector, pointer, index)

--- a/Sources/Dynamic/Logger.swift
+++ b/Sources/Dynamic/Logger.swift
@@ -5,62 +5,69 @@
 //
 
 import Foundation
+import os
 
 protocol Loggable: AnyObject {
     var loggingEnabled: Bool { get }
+}
+
+protocol Logger: AnyObject, Sendable {
+    @discardableResult
+    func log(_ group: LogGroup) -> any Logger
+
+    @discardableResult
+    func log(_ items: [Any]) -> any Logger
+
+    @discardableResult
+    func log(_ items: Any...) -> any Logger
+}
+
+extension Logger {
+    func log(_ items: Any...) -> any Logger {
+        log(items)
+    }
 }
 
 extension Loggable {
     var loggingEnabled: Bool { false }
     var logUsingPrint: Bool { true }
 
-    @discardableResult
-    func log(_ items: Any...) -> Logger {
-        guard loggingEnabled else { return Logger.dummy }
-        return Logger.logger(for: self).log(items)
-    }
+    /// Lazily creates and stores a local debug logger as an associated object.
+    var logger: Logger {
+        let loggerKey = UnsafeRawPointer(bitPattern: Int(bitPattern: ObjectIdentifier(Logger.self)))!
 
-    @discardableResult
-    func log(_ group: Logger.Group) -> Logger {
-        guard loggingEnabled else { return Logger.dummy }
-        return Logger.logger(for: self).log(group)
-    }
-}
-
-class Logger {
-    enum Group {
-        case start, end
-    }
-
-    static let dummy = DummyLogger()
-    static var enabled = true
-
-    private static var loggers: [ObjectIdentifier: Logger] = [:]
-    private static var level: Int = 0
-
-    static func logger(for object: AnyObject) -> Logger {
-        let id = ObjectIdentifier(object)
-        if let logger = Self.loggers[id] {
+        if let logger = objc_getAssociatedObject(self, loggerKey) as? Logger {
             return logger
         }
-
-        let logger = Logger()
-        Self.loggers[id] = logger
-
+        let logger = PrintLogger()
+        objc_setAssociatedObject(self, loggerKey, logger, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         return logger
     }
 
     @discardableResult
-    func log(_ items: Any..., withBullet: Bool = true) -> Logger {
-        log(items, withBullet: withBullet)
+    func log(_ items: Any...) -> Logger {
+        guard loggingEnabled else { return DummyLogger.shared }
+        return logger.log(items)
     }
 
     @discardableResult
-    func log(_ items: [Any], withBullet: Bool = true) -> Logger {
-        guard Self.enabled else { return self }
+    func log(_ group: LogGroup) -> Logger {
+        guard loggingEnabled else { return DummyLogger.shared }
+        return logger.log(group)
+    }
+}
 
+enum LogGroup {
+    case start, end
+}
+
+final class PrintLogger: Logger {
+    private static let level = OSAllocatedUnfairLock(initialState: 0)
+
+    @discardableResult
+    func logUnchecked(_ items: [Any], level: Int, withBullet: Bool = true) -> Logger {
         let message = items.lazy.map { String(describing: $0) }.joined(separator: " ")
-        var indent = String(repeating: " ╷  ", count: Self.level)
+        var indent = String(repeating: " ╷  ", count: level)
         if !indent.isEmpty, withBullet {
             indent = indent.dropLast(2) + "‣ "
         }
@@ -69,7 +76,14 @@ class Logger {
     }
 
     @discardableResult
-    func log(_ group: Group) -> Logger {
+    func log(_ items: [Any]) -> Logger {
+        Self.level.withLockUnchecked { level in
+            logUnchecked(items, level: level)
+        }
+    }
+
+    @discardableResult
+    func log(_ group: LogGroup) -> Logger {
         switch group {
         case .start: logGroupStart()
         case .end: logGroupEnd()
@@ -78,29 +92,31 @@ class Logger {
     }
 
     private func logGroupStart() {
-        guard Self.enabled else { return }
-
-        log([" ╭╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴"], withBullet: false)
-        Self.level += 1
+        Self.level.withLockUnchecked { level in
+            logUnchecked([" ╭╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴"], level: level, withBullet: false)
+            level += 1
+        }
     }
 
     private func logGroupEnd() {
-        guard Self.enabled else { return }
-
-        guard Self.level > 0 else { return }
-        Self.level -= 1
-        log([" ╰╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴"], withBullet: false)
+        Self.level.withLockUnchecked { level in
+            guard level > 0 else { return }
+            level -= 1
+            logUnchecked([" ╰╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴"], level: level, withBullet: false)
+        }
     }
 }
 
-class DummyLogger: Logger {
+final class DummyLogger: Logger {
+    static let shared = DummyLogger()
+
     @discardableResult
-    override func log(_ items: [Any], withBullet: Bool = true) -> Logger {
+    func log(_ items: [Any]) -> Logger {
         self
     }
 
     @discardableResult
-    override func log(_ group: Group) -> Logger {
+    func log(_ group: LogGroup) -> Logger {
         self
     }
 }

--- a/Tests/DynamicTests/DynamicTests.swift
+++ b/Tests/DynamicTests/DynamicTests.swift
@@ -1,96 +1,113 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import Dynamic
 
-final class DynamicTests: XCTestCase {
-    class override func setUp() {
+struct LoggingScope: SuiteTrait, TestScoping {
+    func provideScope(for test: Test, testCase: Test.Case?, performing function: () async throws -> Void) async throws {
         Dynamic.loggingEnabled = true
-//        Logger.enabled = false
+        try await function()
     }
+}
 
-    func testInit() {
+extension SuiteTrait where Self == LoggingScope {
+    static var withLogging: LoggingScope { LoggingScope() }
+}
+
+@Suite(.withLogging)
+@MainActor
+final class DynamicTests {
+    @Test
+    func initialization() {
         let className = "NSDateFormatter"
 
         let formatter1 = ObjC.NSDateFormatter()
-        XCTAssertEqual(formatter1.asObject?.className, className, "Parameterless init")
-        XCTAssert(formatter1.asObject is DateFormatter, "Parameterless init - Bridging")
+        #expect(formatter1.asObject?.className == className, "Parameterless init")
+        #expect(formatter1.asObject is DateFormatter, "Parameterless init - Bridging")
 
         let formatter2 = ObjC.NSDateFormatter.`init`()
-        XCTAssertEqual(formatter2.asObject?.className, className, "Parameterless init with explicit init")
+        #expect(formatter2.asObject?.className == className, "Parameterless init with explicit init")
     }
 
-    func testInitWithParameters() {
+    @Test
+    func initWithParameters() {
         let uuidString = "68753A44-4D6F-1226-9C60-0050E4C00067"
         let className = "__NSConcreteUUID"
 
         let uuid1 = ObjC.NSUUID(UUIDString: uuidString)
-        XCTAssertEqual(uuid1.asObject?.className, className, "Parameterized init")
-        XCTAssertEqual(uuid1.UUIDString.asString, uuidString)
+
+        #expect(uuid1.asObject?.className == className, "Parameterized init")
+        #expect(uuid1.UUIDString.asString == uuidString)
 
         let uuid2 = ObjC.NSUUID.initWithUUIDString(uuidString)
-        XCTAssertEqual(uuid2.asObject?.className, className, "Parameterized init with explicit init")
-        XCTAssertEqual(uuid2.UUIDString.asString, uuidString)
+        #expect(uuid2.asObject?.className == className, "Parameterized init with explicit init")
+        #expect(uuid2.UUIDString.asString == uuidString)
     }
 
+    @Test
     func testClassMethods() {
         let uuidClassName = "__NSConcreteUUID"
         let uuid = ObjC.NSUUID.UUID()
-        XCTAssertEqual(uuid.asObject?.className, uuidClassName, "Class methods")
+        #expect(uuid.asObject?.className == uuidClassName, "Class methods")
 
         let exceptionClassName = "NSException"
         let name = "Dummy"
         let reason = "Testing"
         let userInfo = ["Foo": "Bar"] as NSDictionary
         let exception = ObjC.NSException.exceptionWithName(name, reason: reason, userInfo: userInfo)
-        XCTAssertEqual(exception.asObject?.className, exceptionClassName, "Class methods")
-        XCTAssertEqual(exception.name.asString, name, "Properties passed to the constructor")
-        XCTAssertEqual(exception.reason.asString, reason, "Properties passed to the constructor")
-        XCTAssertEqual(exception.userInfo.asDictionary, userInfo, "Properties passed to the constructor")
+        #expect(exception.asObject?.className == exceptionClassName, "Class methods")
+        #expect(exception.name.asString == name, "Properties passed to the constructor")
+        #expect(exception.reason.asString == reason, "Properties passed to the constructor")
+        #expect(exception.userInfo.asDictionary == userInfo, "Properties passed to the constructor")
     }
 
+    @Test
     func testProperties() {
         let host = "example.com"
         let urlString = "https://\(host)/"
         let urlComponents = ObjC.NSURLComponents.componentsWithString(urlString)
-        XCTAssertEqual(urlComponents.host.asString, host, "Properties passed to the constructor")
+        #expect(urlComponents.host.asString == host, "Properties passed to the constructor")
 
         let host2 = "example2.com"
         urlComponents.host = host2
-        XCTAssertEqual(urlComponents.host.asString, host2, "Setting properties")
+        #expect(urlComponents.host.asString == host2, "Setting properties")
 
         let queryItems = [NSURLQueryItem(name: "foo", value: "bar")] as NSArray
         urlComponents.queryItems = queryItems
-        XCTAssertEqual(urlComponents.queryItems.asArray, queryItems, "Setting properties")
-        XCTAssertEqual(urlComponents.URL, NSURL(string: "https://example2.com/?foo=bar"))
+        #expect(urlComponents.queryItems.asArray == queryItems, "Setting properties")
+        #expect(urlComponents.URL == NSURL(string: "https://example2.com/?foo=bar"))
 
         let progress = ObjC.NSProgress.progressWithTotalUnitCount(100)
         progress.completedUnitCount = 50
-        XCTAssertEqual(progress.fractionCompleted, 0.5, "Setting numeric properties")
+        #expect(progress.fractionCompleted == 0.5, "Setting numeric properties")
 
         let queue = ObjC.NSOperationQueue()
-        XCTAssertFalse(queue.isSuspended!)
+        #expect(!queue.isSuspended!)
         queue.isSuspended = true
-        XCTAssertTrue(queue.isSuspended!, "Setting boolean properties with 'is' prefix")
+        #expect(queue.isSuspended!, "Setting boolean properties with 'is' prefix")
     }
 
-    func testBlocks() {
+    @Test
+    func blocks() async {
         // swiftlint:disable:next nesting
         typealias VoidBlock = @convention(block) () -> Void
 
-        let closure1Called = expectation(description: "Closure 1")
+        var closure1Called = false
         let progress = ObjC.NSProgress.progressWithTotalUnitCount(100)
         progress.cancellationHandler = {
-            closure1Called.fulfill()
+            closure1Called = true
         } as VoidBlock
         progress.cancel()
 
-        let closure2Called = expectation(description: "Closure 2")
+        var closure2Called = false
         let operation = ObjC.NSBlockOperation.blockOperationWithBlock({
-            closure2Called.fulfill()
+            closure2Called = true
         } as VoidBlock)
         ObjC.NSOperationQueue.mainQueue.addOperation(operation)
 
-        waitForExpectations(timeout: 0.1, handler: nil)
+        try? await Task.sleep(for: .milliseconds(100))
+        #expect(closure1Called)
+        #expect(closure2Called)
     }
 
     func testExplicitUnwrapping() {
@@ -104,30 +121,20 @@ final class DynamicTests: XCTestCase {
         let processInfo1 = ProcessInfo.processInfo
         let processInfo2 = ObjC.NSProcessInfo.processInfo
 
-        XCTAssertEqual(processInfo1.processIdentifier,
-                       processInfo2.processIdentifier.asInt32, "Int32")
-        XCTAssertEqual(processInfo1.processorCount,
-                       processInfo2.processorCount.asInt, "Int")
-        XCTAssertEqual(processInfo1.physicalMemory,
-                       processInfo2.physicalMemory.asUInt64, "UInt64")
-        XCTAssertEqual(processInfo1.systemUptime,
-                       processInfo2.systemUptime.asDouble ?? 0, accuracy: 1, "Double")
-        XCTAssertEqual(processInfo1.arguments as NSArray,
-                       processInfo2.arguments.asArray, "Array")
-        XCTAssertEqual(processInfo1.arguments,
-                       processInfo2.arguments.asInferred(), "Array")
-        XCTAssertEqual(processInfo1.environment as NSDictionary,
-                       processInfo2.environment, "Dictionary")
-        XCTAssertEqual(processInfo1.processName,
-                       processInfo2.processName.asString, "String")
+        #expect(processInfo1.processIdentifier == processInfo2.processIdentifier.asInt32, "Int32")
+        #expect(processInfo1.processorCount == processInfo2.processorCount.asInt, "Int")
+        #expect(processInfo1.physicalMemory == processInfo2.physicalMemory.asUInt64, "UInt64")
+        #expect(processInfo1.systemUptime == processInfo2.systemUptime.asDouble ?? 0, "Double")
+        #expect(processInfo1.arguments as NSArray == processInfo2.arguments.asArray, "Array")
+        #expect(processInfo1.arguments == processInfo2.arguments.asInferred(), "Array")
+        #expect(processInfo1.environment as NSDictionary == processInfo2.environment, "Dictionary")
+        #expect(processInfo1.processName == processInfo2.processName.asString, "String")
 
         let version1 = processInfo1.operatingSystemVersion
         let version2: NSOperatingSystemVersion? = processInfo2.operatingSystemVersion.asInferred()
-        XCTAssertEqual(version1.majorVersion,
-                       version2?.majorVersion, "Struct")
+        #expect(version1.majorVersion == version2?.majorVersion, "Struct")
 
-        XCTAssertEqual(processInfo1.isOperatingSystemAtLeast(version1),
-                       processInfo2.isOperatingSystemAtLeastVersion(version2).asBool, "Bool")
+        #expect(processInfo1.isOperatingSystemAtLeast(version1) == processInfo2.isOperatingSystemAtLeastVersion(version2).asBool, "Bool")
     }
 
     func testImplicitUnwrapping() {
@@ -141,92 +148,86 @@ final class DynamicTests: XCTestCase {
         let processInfo1 = ProcessInfo.processInfo
         let processInfo2 = ObjC.NSProcessInfo.processInfo
 
-        XCTAssertEqual(processInfo1.processIdentifier,
-                       processInfo2.processIdentifier, "Int32")
-        XCTAssertEqual(processInfo1.processorCount,
-                       processInfo2.processorCount, "Int")
-        XCTAssertEqual(processInfo1.physicalMemory,
-                       processInfo2.physicalMemory, "UInt64")
-        XCTAssertEqual(processInfo1.systemUptime,
-                       processInfo2.systemUptime ?? 0, accuracy: 1, "Double")
-        XCTAssertEqual(processInfo1.arguments,
-                       processInfo2.arguments, "Array")
-        XCTAssertEqual(processInfo1.environment,
-                       processInfo2.environment, "Dictionary")
-        XCTAssertEqual(processInfo1.processName,
-                       processInfo2.processName, "String")
+        #expect(processInfo1.processIdentifier == processInfo2.processIdentifier, "Int32")
+        #expect(processInfo1.processorCount == processInfo2.processorCount, "Int")
+        #expect(processInfo1.physicalMemory == processInfo2.physicalMemory, "UInt64")
+        #expect(Int(processInfo1.systemUptime) == Int(processInfo2.systemUptime ?? 0), "Double")
+        #expect(processInfo1.arguments == processInfo2.arguments, "Array")
+        #expect(processInfo1.environment == processInfo2.environment, "Dictionary")
+        #expect(processInfo1.processName == processInfo2.processName, "String")
 
         let version1 = processInfo1.operatingSystemVersion
         let version2: NSOperatingSystemVersion? = processInfo2.operatingSystemVersion
-        XCTAssertEqual(version1.majorVersion,
-                       version2?.majorVersion, "Struct")
+        #expect(version1.majorVersion == version2?.majorVersion, "Struct")
 
-        XCTAssertEqual(processInfo1.isOperatingSystemAtLeast(version1),
-                       processInfo2.isOperatingSystemAtLeastVersion(version2), "Bool")
+        #expect(processInfo1.isOperatingSystemAtLeast(version1) == processInfo2.isOperatingSystemAtLeastVersion(version2), "Bool")
 
         let formatter1 = ObjC.NSDateFormatter()
-        XCTAssertTrue(type(of: formatter1) == Dynamic.self, "Type should be Dynamic")
+        #expect(type(of: formatter1) == Dynamic.self, "Type should be Dynamic")
 
         let formatter2: NSObject? = ObjC.NSDateFormatter()
-        XCTAssertEqual(formatter2?.className, "NSDateFormatter", "Value isn't unwrapped")
+        #expect(formatter2?.className == "NSDateFormatter", "Value isn't unwrapped")
 
         let formatter3 = { () -> NSObject? in
             ObjC.NSDateFormatter()
         }()
-        XCTAssertEqual(formatter3?.className, "NSDateFormatter", "Value isn't unwrapped")
+        #expect(formatter3?.className == "NSDateFormatter", "Value isn't unwrapped")
 
         formatter1.dateFormat = ObjC("yyyy-MM-dd HH:mm:ss")
         let date = ObjC.NSDate(timeIntervalSince1970: 1_600_000_000)
         let string: String? = formatter1.stringFromDate(date)
         let newDate: Date? = formatter1.dateFromString(string)
-        XCTAssertEqual(date.asInferred(),
-                       newDate, "Value isn't unwrapped")
+        #expect(date.asInferred() == newDate, "Value isn't unwrapped")
 
-        XCTAssertEqual(date.asObject,
-                       formatter1.dateFromString(formatter1.stringFromDate(date)), "Value isn't unwrapped")
+        #expect(date.asObject == formatter1.dateFromString(formatter1.stringFromDate(date)), "Value isn't unwrapped")
     }
 
     func testEdgeCases() {
         let error = ObjC.NSDateFormatter().invalidMethod()
-        XCTAssertTrue(error.asObject is Error, "Calling non existing method should return error")
-        XCTAssertTrue(error.isError, "isError should return true for errors")
+        #expect(error.asObject is Error, "Calling non existing method should return error")
+        #expect(error.isError, "isError should return true for errors")
 
         let errorChained = error.thisMethodCallHasNoEffect(123).randomProperty
-        XCTAssertTrue(errorChained === error, "Calling methods and properties form error should return the same object")
+        #expect(errorChained === error, "Calling methods and properties form error should return the same object")
 
         let null = ObjC.nil
-        XCTAssertNil(null.asObject, "Wrapped nil should return nil")
+        #expect(null.asObject == nil, "Wrapped nil should return nil")
 
         let nullChained = null.thisMethodCallHasNoEffect(123).randomProperty
-        XCTAssertTrue(nullChained === null, "Calling methods and properties form <nil> should return the same object")
+        #expect(nullChained === null, "Calling methods and properties form <nil> should return the same object")
 
         let formatter = ObjC.NSDateFormatter()
-        XCTAssertEqual(formatter.stringFromDate(Date()), "", "Should return an empty string")
+        #expect(formatter.stringFromDate(Date()) == "", "Should return an empty string")
         formatter.dateFormat = ObjC("yyyy-MM-dd HH:mm:ss")
-        XCTAssertNotEqual(formatter.stringFromDate(Date()), "", "Should NOT return an empty string")
+        #expect(formatter.stringFromDate(Date()) != "", "Should NOT return an empty string")
 
         formatter.dateFormat = .nil
-        XCTAssertEqual(formatter.stringFromDate(Date()), "", "Should return an empty string")
+        #expect(formatter.stringFromDate(Date()) == "", "Should return an empty string")
         formatter.dateFormat = ObjC("yyyy-MM-dd HH:mm:ss")
-        XCTAssertNotEqual(formatter.stringFromDate(Date()), "", "Should NOT return an empty string")
+        #expect(formatter.stringFromDate(Date()) != "", "Should NOT return an empty string")
 
         formatter.dateFormat = nil as String? // or String?.none
-        XCTAssertEqual(formatter.stringFromDate(Date()), "", "Should return an empty string")
+        #expect(formatter.stringFromDate(Date()) == "", "Should return an empty string")
     }
 
     func testAlternativeMethodNames() {
         let formatter = ObjC.NSDateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        XCTAssertEqual(formatter.stringFromDate(Date()).asString,
-                       formatter.stringFrom(date: Date()), "Alternative methods should work as the original")
+        #expect(
+            formatter.stringFromDate(Date()).asString ==
+                formatter.stringFrom(date: Date()),
+            "Alternative methods should work as the original")
 
-        XCTAssertEqual(formatter.stringFromDate(Date()).asString,
-                       formatter.string(fromDate: Date()), "Alternative methods should work as the original")
+        #expect(
+            formatter.stringFromDate(Date()).asString ==
+                formatter.string(fromDate: Date()),
+            "Alternative methods should work as the original")
 
         let progress1 = ObjC.NSProgress.progressWithTotalUnitCount(99)
         let progress2 = ObjC.NSProgress.progress(withTotalUnitCount: 99)
-        XCTAssertEqual(progress1.totalUnitCount.asInt,
-                       progress2.totalUnitCount.asInt, "Alternative methods should work as the original")
+        #expect(
+            progress1.totalUnitCount.asInt == progress2.totalUnitCount.asInt,
+            "Alternative methods should work as the original")
     }
 
     func testHiddenAPI() {
@@ -241,7 +242,7 @@ final class DynamicTests: XCTestCase {
             _ = withUnsafeMutablePointer(to: &result) { pointer in
                 invocation.getReturnValue(pointer)
             }
-            XCTAssertEqual(result, "abc", "Can't use hidden API")
+            #expect(result == "abc", "Can't use hidden API")
             if let string = result {
                 _ = Unmanaged.passRetained(string).takeUnretainedValue()
             }
@@ -271,7 +272,7 @@ final class DynamicTests: XCTestCase {
             _ = withUnsafeMutablePointer(to: &result) { pointer in
                 invocation.getReturnValue(pointer)
             }
-            XCTAssertEqual(result, "ABC123", "Can't use hidden API")
+            #expect(result == "ABC123", "Can't use hidden API")
             if let string = result {
                 _ = Unmanaged.passRetained(string).takeUnretainedValue()
             }


### PR DESCRIPTION
Hi!

Happy to pull this into several PRs, right now it's broken up into a few commits that describe the work.

- Update the package to Swift 6 and raise minimum deployment targets to iOS 16-aligned releases (2023)
- Fix concurrency issues
  - The global statics that control logging were unprotected; this uses OSAllocatedUnfairLock to protect them in a way that the concurrency system understands.
  - Also take this opportunity to replace the global dictionary (which is never cleaned up) with an associated object on Dynamic instances that's lazily created.
  - This also protocolizes Logger to make it easier to enforce Sendable requirements.
- Migrate the tests from XCTest to Swift Testing
- Replaces the `UnsafeMutablePointer` allocation (heap) with `withUnsafeTemporaryAllocation` (stack).